### PR TITLE
Admin vê filiais cadastradas

### DIFF
--- a/app/controllers/subsidiaries_controller.rb
+++ b/app/controllers/subsidiaries_controller.rb
@@ -1,5 +1,7 @@
 class SubsidiariesController < ApplicationController
-  def index; end
+  def index
+    @subsidiaries = Subsidiary.all
+  end
 
   def show
     @subsidiary = Subsidiary.find(params[:id])

--- a/app/views/subsidiaries/index.html.erb
+++ b/app/views/subsidiaries/index.html.erb
@@ -1,1 +1,9 @@
+<% if @subsidiaries.empty? %>
+  <p>Não há filiais cadastradas</p>
+<% end %>
+
+<%= @subsidiaries.each do |subsidiary| %>
+  <p><%= subsidiary.name %></p>
+<% end %>
+
 <%= link_to 'Adicionar filial', new_subsidiary_path %>

--- a/app/views/subsidiaries/index.html.erb
+++ b/app/views/subsidiaries/index.html.erb
@@ -2,8 +2,14 @@
   <p>Não há filiais cadastradas</p>
 <% end %>
 
-<%= @subsidiaries.each do |subsidiary| %>
-  <p><%= subsidiary.name %></p>
-<% end %>
+<ul>
+  <% @subsidiaries.each do |subsidiary| %>
+    <li>
+      <%= link_to subsidiary.name, subsidiary %>
+      <%= subsidiary.token %>
+    </li>
+  <% end %>
+</ul>
 
 <%= link_to 'Adicionar filial', new_subsidiary_path %>
+<%= link_to 'Voltar', root_path %>

--- a/app/views/subsidiaries/show.html.erb
+++ b/app/views/subsidiaries/show.html.erb
@@ -1,8 +1,12 @@
-<h1><%= @subsidiary.name %></h1>
-<p>
-  <%= @subsidiary.address %>
-</p>
+<dl>
+  <dt><%= Subsidiary.human_attribute_name(:name) %></dt>
+  <dd><%= @subsidiary.name %></dd>
+  <dt><%= Subsidiary.human_attribute_name(:address) %></dt>
+  <dd><%= @subsidiary.address %></dd>
+  <dt><%= Subsidiary.human_attribute_name(:cnpj) %></dt>
+  <dd><%= @subsidiary.cnpj %></dd>
+  <dt><%= Subsidiary.human_attribute_name(:token) %></dt>
+  <dd><%= @subsidiary.token %></dd>
+</dl>
 
-<p>
-  <%= @subsidiary.cnpj %>
-</p>
+<%= link_to 'Voltar', subsidiaries_path %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+include FactoryBot::Syntax::Methods
+create(:user, email: 'admin@espertofit.com.br')
+create(:subsidiary)
+create(:subsidiary)
+create(:subsidiary)

--- a/spec/features/admin_create_subsidiary_spec.rb
+++ b/spec/features/admin_create_subsidiary_spec.rb
@@ -20,6 +20,12 @@ feature 'Admin creates subsidiary' do
     expect(page).to have_content('R. Lorem Ipsum, 123 - Vila Olímpia - São Paulo/SP')
   end
 
+  scenario 'must be logged in' do
+    visit new_subsidiary_path
+
+    expect(page).to have_content('Para continuar, efetue login ou registre-se.')
+  end
+
   scenario 'must fill in all fields' do
     user = create(:user)
 

--- a/spec/features/admin_view_subsidiaries_spec.rb
+++ b/spec/features/admin_view_subsidiaries_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature 'Admin view subsidiaries' do
+  scenario 'successfully' do
+    user = create(:user)
+    create(:subsidiary, name: 'Osasco')
+    create(:subsidiary, name: 'Pinheiros')
+    create(:subsidiary, name: 'Vila Olímpia')
+
+    login_as user
+    visit root_path
+    click_on 'Gerenciar filiais'
+
+    expect(page).to have_content('Osasco')
+    expect(page).to have_content('Pinheiros')
+    expect(page).to have_content('Vila Olímpia')
+  end
+
+  scenario 'and there are no subsidiaries' do
+    user = create(:user)
+
+    login_as user
+    visit root_path
+    click_on 'Gerenciar filiais'
+
+    expect(page).to have_content('Não há filiais cadastradas')
+  end
+end

--- a/spec/features/admin_view_subsidiaries_spec.rb
+++ b/spec/features/admin_view_subsidiaries_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 feature 'Admin view subsidiaries' do
-  scenario 'successfully' do
+  scenario 'succesfully' do
     user = create(:user)
-    create(:subsidiary, name: 'Osasco')
-    create(:subsidiary, name: 'Pinheiros')
-    create(:subsidiary, name: 'Vila Olímpia')
+    subsidiary = create(:subsidiary, name: 'Osasco')
+    subsidiary2 = create(:subsidiary, name: 'Pinheiros')
+    subsidiary3 = create(:subsidiary, name: 'Vila Olímpia')
 
     login_as user
     visit root_path
@@ -14,6 +14,24 @@ feature 'Admin view subsidiaries' do
     expect(page).to have_content('Osasco')
     expect(page).to have_content('Pinheiros')
     expect(page).to have_content('Vila Olímpia')
+    expect(page).to have_content(subsidiary.token)
+    expect(page).to have_content(subsidiary2.token)
+    expect(page).to have_content(subsidiary3.token)
+  end
+
+  scenario 'and view details' do
+    user = create(:user)
+    subsidiary = create(:subsidiary, name: 'Osasco')
+
+    login_as user
+    visit root_path
+    click_on 'Gerenciar filiais'
+    click_on 'Osasco'
+
+    expect(page).to have_content(subsidiary.name)
+    expect(page).to have_content(subsidiary.address)
+    expect(page).to have_content(subsidiary.cnpj)
+    expect(page).to have_content(subsidiary.token)
   end
 
   scenario 'and there are no subsidiaries' do
@@ -24,5 +42,36 @@ feature 'Admin view subsidiaries' do
     click_on 'Gerenciar filiais'
 
     expect(page).to have_content('Não há filiais cadastradas')
+  end
+
+  scenario 'must be logged in' do
+    visit subsidiaries_path
+
+    expect(page).to have_content('Para continuar, efetue login ou registre-se.')
+  end
+
+  scenario 'and return to index from show' do
+    user = create(:user)
+    subsidiary = create(:subsidiary)
+
+    login_as user
+    visit root_path
+    click_on 'Gerenciar filiais'
+    click_on subsidiary.name
+    click_on 'Voltar'
+
+    expect(current_path).to eq(subsidiaries_path)
+  end
+
+  scenario 'and return to home page from index' do
+    user = create(:user)
+    create(:subsidiary)
+
+    login_as user
+    visit root_path
+    click_on 'Gerenciar filiais'
+    click_on 'Voltar'
+
+    expect(current_path).to eq(root_path)
   end
 end

--- a/spec/features/admin_view_subsidiaries_spec.rb
+++ b/spec/features/admin_view_subsidiaries_spec.rb
@@ -44,8 +44,15 @@ feature 'Admin view subsidiaries' do
     expect(page).to have_content('Não há filiais cadastradas')
   end
 
-  scenario 'must be logged in' do
+  scenario 'must be logged in to view index' do
     visit subsidiaries_path
+
+    expect(page).to have_content('Para continuar, efetue login ou registre-se.')
+  end
+
+  scenario 'must be logged in to view details' do
+    subsidiary = create(:subsidiary)
+    visit subsidiary_path(subsidiary.id)
 
     expect(page).to have_content('Para continuar, efetue login ou registre-se.')
   end


### PR DESCRIPTION
Admin vê todas filiais cadastradas ao clicar em 'Gerenciar filiais', e vê mensagem quando não há filiais. Também vê detalhes de uma filial.
Criado teste de autenticação para o new de filiais.

Fix #11 

Co-authored-by: Gabriel <gscmonteiro@gmail.com>