### PR TITLE
API subsidiaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,34 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## API
+
+### Consulta de filiais
+
+#### GET /api/v1/subsidiaries
+
+**HTTP status:** 200
+
+```json
+[
+  {
+    "id":1,
+    "name":"Lorem1",
+    "address":"R. Lorem Ipsum, XXX, Lorem, Ipsum",
+    "created_at":"2020-10-07T15:38:01.558Z",
+    "updated_at":"2020-10-07T15:38:01.558Z",
+    "cnpj":"73.590.707/9101-24",
+    "token":"9F7IYV"
+  },
+  {
+    "id":2,
+    "name":"Lorem2",
+    "address":"R. Lorem Ipsum, XXX, Lorem, Ipsum",
+    "created_at":"2020-10-07T15:38:01.563Z",
+    "updated_at":"2020-10-07T15:38:01.563Z",
+    "cnpj":"86.837.657/2840-59",
+    "token":"CK4XEB"
+  }
+]
+```

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::ApiController < ActionController::API
+end

--- a/app/controllers/api/v1/subsidiaries_controller.rb
+++ b/app/controllers/api/v1/subsidiaries_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::SubsidiariesController < Api::V1::ApiController
+  def index
+    @subsidiaries = Subsidiary.all
+    render json: @subsidiaries
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,10 @@ Rails.application.routes.draw do
 
   resources :plans, only: %i[index new create show]
   resources :subsidiaries, only: %i[index show new create]
+
+  namespace :api, constraints: { format: :json } do
+    namespace :v1 do
+      resources :subsidiaries, only: %i[index]
+    end
+  end
 end

--- a/spec/requests/api_subsidiary_spec.rb
+++ b/spec/requests/api_subsidiary_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Api subsidiary' do
+  context 'GET api/v1/subsidiaries' do
+    it 'successfully' do
+      subsidiaries = create_list(:subsidiary, 2)
+
+      get api_v1_subsidiaries_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('application/json')
+      expect(response.body).to eq subsidiaries.to_json
+    end
+
+    it 'empty subsidiaries' do
+      get api_v1_subsidiaries_path
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Motivação

Criar uma API para listar filais para ser consumida por um sistema externo

## Solução proposta

Criar um `index` de `subsidiaries` num namespace especifico para podermos versionar nossa API. Também incluí uma documentação para facilitar aos outros times a consulta.