### PR TITLE
Admin edita plano

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,5 @@
 class PlansController < ApplicationController
+  before_action :set_plan, only: %i[show edit update]
   def index
     @plans = Plan.all
   end
@@ -14,11 +15,23 @@ class PlansController < ApplicationController
     render :new
   end
 
-  def show
-    @plan = Plan.find(params[:id])
+  def show; end
+
+  def edit; end
+
+  def update
+    return redirect_to @plan if @plan.update(plan_params)
+
+    render :edit
   end
+
+  private
 
   def plan_params
     params.require(:plan).permit(:name, :default_price, :minimum_period)
+  end
+
+  def set_plan
+    @plan = Plan.find(params[:id])
   end
 end

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: @plan, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <div>
+  <%= f.label :default_price %>
+  <%= f.number_field :default_price %>
+  </div>
+  <div>
+  <%= f.label :minimum_period %> (meses)
+  <%= f.number_field :minimum_period %>
+  </div>
+  <div>
+  <%= f.submit 'Enviar' %>
+  </div>
+<% end %>

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -1,0 +1,9 @@
+<h3>Editar plano:</h3>
+
+<% if @plan.errors.present? %>
+  <% @plan.errors.full_messages.each do |message| %>
+    <%= message %>
+  <% end %>
+<% end %>
+
+<%= render partial: 'form', locals: { plan: @plan } %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -12,7 +12,7 @@
     </tr>
   <% @plans.each do |plan| %>
     <tr>
-      <td><%= plan.name %></td>
+      <td><%= link_to "#{plan.name}", plan %></td>
       <td><%= number_to_currency plan.default_price %></td>
       <td><%= plan.minimum_period %> meses</td>
     </tr>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -12,7 +12,7 @@
     </tr>
   <% @plans.each do |plan| %>
     <tr>
-      <td><%= link_to "#{plan.name}", plan %></td>
+      <td><%= link_to plan.name, plan %></td>
       <td><%= number_to_currency plan.default_price %></td>
       <td><%= plan.minimum_period %> meses</td>
     </tr>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -4,4 +4,4 @@
  <%end%>
 <%end%>
 
-<%= render partial: 'form', locals: {plan: @plan} %>
+<%= render partial: 'form', locals: { plan: @plan } %>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -1,23 +1,7 @@
-
- <% if @plan.errors.present? %>
-  <% @plan.errors.full_messages.each do |message| %>
-     <%= message %>
-  <%end%>
+<% if @plan.errors.present? %>
+ <% @plan.errors.full_messages.each do |message| %>
+    <%= message %>
  <%end%>
+<%end%>
 
-
-<%= form_with model: @plan, local: true do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
-  <div>
-  <%= f.label :default_price %>
-  <%= f.number_field :default_price %>
-  </div>
-  <div>
-  <%= f.label :minimum_period %> (meses)
-  <%= f.number_field :minimum_period %>
-  </div>
-  <div>
-  <%= f.submit 'Criar plano'%>
-  </div>
-<% end %>
+<%= render partial: 'form', locals: {plan: @plan} %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,4 +1,5 @@
 <%= link_to 'Voltar', plans_path %>
+<%= link_to 'Editar plano', edit_plan_path(@plan)%>
 
 <dl>
   <dt><%= Plan.human_attribute_name(:name) %></dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'home#index'
 
-  resources :plans, only: %i[index new create show]
+  resources :plans, only: %i[index new create show edit update]
   resources :enrollments, only: %i[index show]
   resources :subsidiaries, only: %i[index show new create] do
     resources :subsidiary_plans, only: %i[new create]

--- a/spec/features/admin_creates_a_plan_spec.rb
+++ b/spec/features/admin_creates_a_plan_spec.rb
@@ -15,7 +15,7 @@ feature 'Admin creates a plan' do
     fill_in 'Nome', with: 'Premium'
     fill_in 'Preço padrão', with: '100.00'
     fill_in 'Permanência mínima', with: '6'
-    click_on 'Criar plano'
+    click_on 'Enviar'
 
     expect(page).to have_link('Voltar', href: plans_path)
     expect(page).to have_content('Premium')
@@ -33,7 +33,7 @@ feature 'Admin creates a plan' do
     fill_in 'Nome', with: ''
     fill_in 'Preço padrão', with: ''
     fill_in 'Permanência mínima', with: ''
-    click_on 'Criar plano'
+    click_on 'Enviar'
 
     expect(page).to have_content('não pode ficar em branco', count: 3)
   end
@@ -49,7 +49,7 @@ feature 'Admin creates a plan' do
     fill_in 'Nome', with: 'Premium'
     fill_in 'Preço padrão', with: '100.00'
     fill_in 'Permanência mínima', with: '12'
-    click_on 'Criar plano'
+    click_on 'Enviar'
 
     expect(page).to have_content('Nome já está em uso')
   end
@@ -64,7 +64,7 @@ feature 'Admin creates a plan' do
     fill_in 'Nome', with: 'Premium'
     fill_in 'Preço padrão', with: '-1.00'
     fill_in 'Permanência mínima', with: '-10'
-    click_on 'Criar plano'
+    click_on 'Enviar'
 
     expect(page).to have_content('Preço padrão deve ser maior que 0')
     expect(page).to have_content('Permanência mínima deve ser maior que 0')

--- a/spec/features/admin_edit_plan_spec.rb
+++ b/spec/features/admin_edit_plan_spec.rb
@@ -1,0 +1,90 @@
+feature 'Admin edit plan' do
+  scenario 'and must be logged in' do
+    plan = create(:plan)
+
+    visit edit_plan_path(plan)
+
+    expect(current_path).to eq new_user_session_path
+  end
+
+  scenario 'successfully' do
+    user = create(:user)
+    create(:plan, name: 'Básico', default_price: '79.00',
+                  minimum_period: 6)
+
+    login_as(user, scope: :user)
+    visit root_path
+    click_on 'Gerenciar planos'
+    click_on 'Básico'
+    click_on 'Editar plano'
+    fill_in 'Nome', with: 'Super básico'
+    fill_in 'Preço padrão', with: '50.00'
+    fill_in 'Permanência mínima', with: '4'
+    click_on 'Enviar'
+
+    expect(page).to have_content('Super básico')
+    expect(page).to have_content('R$ 50,00')
+    expect(page).to have_content('4 meses')
+  end
+
+  scenario 'and fields cant be blank' do
+    user = create(:user)
+    plan = create(:plan, name: 'Básico', default_price: '79.00',
+                         minimum_period: 6)
+
+    login_as(user, scope: :user)
+    visit plan_path(plan)
+    click_on 'Editar plano'
+    fill_in 'Nome', with: ''
+    fill_in 'Preço padrão', with: ''
+    fill_in 'Permanência mínima', with: ''
+    click_on 'Enviar'
+
+    expect(page).to have_content('não pode ficar em branco', count: 3)
+  end
+
+  scenario 'and minimum period must be grater than 0' do
+    user = create(:user)
+    plan = create(:plan, name: 'Básico', default_price: '79.00',
+                         minimum_period: 6)
+
+    login_as(user, scope: :user)
+    visit edit_plan_path(plan)
+    fill_in 'Nome', with: 'Básico'
+    fill_in 'Preço padrão', with: '100.99'
+    fill_in 'Permanência mínima', with: '-10.00'
+    click_on 'Enviar'
+
+    expect(page).to have_content('Permanência mínima deve ser maior que 0')
+  end
+
+  scenario 'and default price must be greater than 0' do
+    user = create(:user)
+    plan = create(:plan, name: 'Básico', default_price: '79.00',
+                         minimum_period: 6)
+
+    login_as(user, scope: :user)
+    visit edit_plan_path(plan)
+    fill_in 'Nome', with: 'Básico'
+    fill_in 'Preço padrão', with: '-1'
+    fill_in 'Permanência mínima', with: '2'
+    click_on 'Enviar'
+
+    expect(page).to have_content('Preço padrão deve ser maior que 0')
+  end
+
+  scenario 'and name must be unique' do
+    user = create(:user)
+    basic_plan = create(:plan, name: 'Básico', default_price: '79.00',
+                               minimum_period: 6)
+    create(:plan, name: 'Premium', default_price: '100.00',
+                  minimum_period: 12)
+
+    login_as(user, scope: :user)
+    visit edit_plan_path(basic_plan)
+    fill_in 'Nome', with: 'Premium'
+    click_on 'Enviar'
+
+    expect(page).to have_content('Nome já está em uso')
+  end
+end


### PR DESCRIPTION
Administrado, após estar logado, pode escolher um plano e editar seus atributos: nome, preço padrão e período mínimo de permanência no plano. Onde o nome não pode se repetir, preço padrão e período mínimo devem ser maiores do que zero.
Após editar, o administrador volta para o `show` desse plano.

closes: #22 