### PR TITLE
Api consulta de cpf banido

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,18 @@ Parâmetros inválidos
   "CPF do cliente não é válido"
 ]
 ```
+### Consulta de CPF banido
+
+#### GET /api/v1/banned_customer/:cpf
+
+**HTTP status:** 200 (CPF banido)
+
+**HTTP status:** 404 (CPF não encontrado na lista de banidos)
+
+**HTTP status:** 422 (CPF inválido)
+
+```json
+{
+  "message": "CPF inválido"
+}
+```

--- a/app/controllers/api/v1/banned_customers_controller.rb
+++ b/app/controllers/api/v1/banned_customers_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::BannedCustomersController < Api::V1::ApiController
+  def show
+    banned_cpf = CPF.new(params[:cpf]).formatted
+    return render status: :unprocessable_entity, json: { message: 'CPF inválido' } unless CPF.valid?(banned_cpf)
+
+    @banned_customer = BannedCustomer.find_by(cpf: banned_cpf)
+    if @banned_customer
+      render status: :ok
+    else
+      render status: :not_found
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :subsidiaries, only: %i[index]
       resources :enrollments, only: %i[create]
+      get '/banned_customer/:cpf', to: 'banned_customers#show', as: 'banned_customer'
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2020_10_14_224033) do
   create_table "banned_customers", force: :cascade do |t|
     t.text "reason", null: false
     t.datetime "banned_at", null: false
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.string "cpf", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/requests/api_banned_cpf_spec.rb
+++ b/spec/requests/api_banned_cpf_spec.rb
@@ -1,0 +1,24 @@
+describe 'API banned cpf' do
+  context 'GET api/v1/banned_customer/:cpf' do
+    it 'successfully' do
+      banned_customer = create(:banned_customer, cpf: '435.955.239-46')
+
+      get api_v1_banned_customer_path(CPF.new(banned_customer.cpf).stripped)
+
+      expect(response).to be_ok
+    end
+
+    it 'cpf is not found' do
+      get api_v1_banned_customer_path('43595523946')
+
+      expect(response).to be_not_found
+    end
+
+    it 'cpf is invalid' do
+      get api_v1_banned_customer_path('12345')
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('CPF inválido')
+    end
+  end
+end


### PR DESCRIPTION
Esse PR adiciona rota para consulta de CPF banido, retornando status: 200, 404 ou 422  de acordo com a requisição.

Co-authored-by: Felipe <flp.far@gmail.com>

closes: #28 